### PR TITLE
Add GitHub actions for CI

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,0 +1,49 @@
+name: Main
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+      - master
+      - release/**
+  pull_request:
+    branches:
+      - main
+      - master
+      - release/**
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  run:
+    runs-on: ${{ matrix.operating-system }}
+    strategy:
+      matrix:
+        operating-system: ['ubuntu-latest', 'macos-latest']
+        php-versions: ['5.6', '7.0', '7.1', '7.2', '7.3', '7.4']
+    steps:
+    - name: Get source code
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+    - name: Setup PHP
+      uses: shivammathur/setup-php@v2
+      with:
+        php-version: ${{ matrix.php-versions }}
+        coverage: none
+        ini-values: post_max_size=256M, max_execution_time=180
+    - run: sudo pear list
+    - run: sudo pear channel-update pear.php.net
+    - run: sudo pear upgrade --force pear/pear
+    - run: sudo pear list
+    - run: sudo pear install --force package.xml
+    - run: sudo pear list
+    - run: sudo pear package
+    - run: sudo pear package-validate
+    - run: sudo pear install --force *.tgz
+    - run: sudo pear list
+    - run: composer install
+    - run: ./vendor/bin/phpunit tests


### PR DESCRIPTION
#2 ported the test suite to to [PHPUniPolyFills](https://github.com/Yoast/PHPUnit-Polyfills). This PR adds CI in form of GitHub actions. This is another step on the road to port the code to PHP 8.

# Technical details

  - The test suite itself is not changed.
  - We use [Setup PHP Action](https://github.com/marketplace/actions/setup-php-action) to set up PHP.
  - We test up to PHP 7.4 for now since the code doesn't run on PHP 8.
  - We test under Ubuntu and macOS.
  - The action is configured to run on pull requests and when pushing on certain branches.