### PR TITLE
Port to PHP 8

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,0 +1,49 @@
+name: Main
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+      - master
+      - release/**
+  pull_request:
+    branches:
+      - main
+      - master
+      - release/**
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  run:
+    runs-on: ${{ matrix.operating-system }}
+    strategy:
+      matrix:
+        operating-system: ['ubuntu-latest', 'macos-latest']
+        php-versions: ['5.6', '7.0', '7.1', '7.2', '7.3', '7.4']
+    steps:
+    - name: Get source code
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+    - name: Setup PHP
+      uses: shivammathur/setup-php@v2
+      with:
+        php-version: ${{ matrix.php-versions }}
+        coverage: none
+        ini-values: post_max_size=256M, max_execution_time=180
+    - run: sudo pear list
+    - run: sudo pear channel-update pear.php.net
+    - run: sudo pear upgrade --force pear/pear
+    - run: sudo pear list
+    - run: sudo pear install --force package.xml
+    - run: sudo pear list
+    - run: sudo pear package
+    - run: sudo pear package-validate
+    - run: sudo pear install --force *.tgz
+    - run: sudo pear list
+    - run: composer install
+    - run: ./vendor/bin/phpunit tests

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       matrix:
         operating-system: ['ubuntu-latest', 'macos-latest']
-        php-versions: ['5.6', '7.0', '7.1', '7.2', '7.3', '7.4']
+        php-versions: ['5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3']
     steps:
     - name: Get source code
       uses: actions/checkout@v4

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -23,7 +23,6 @@ jobs:
     strategy:
       matrix:
         operating-system: ['ubuntu-latest', 'macos-latest']
-
         php-versions: ['5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
     steps:
     - name: Get source code

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       matrix:
         operating-system: ['ubuntu-latest', 'macos-latest']
-        php-versions: ['5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3']
+        php-versions: ['5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
     steps:
     - name: Get source code
       uses: actions/checkout@v4

--- a/Image/Color.php
+++ b/Image/Color.php
@@ -494,7 +494,7 @@ class Image_Color
     {
         $c = array();
 
-        if ($color{0} == '#') {
+        if ($color[0] == '#') {
             $c = Image_Color::hex2rgb($color);
         } else {
             $c = Image_Color::namedColor2RGB($color);

--- a/Image/Color.php
+++ b/Image/Color.php
@@ -470,7 +470,7 @@ class Image_Color
      * @uses    ImageColorAllocate() to allocate the color.
      * @uses    color2RGB() to parse the color into RGB values.
      */
-    function allocateColor(&$img, $color) {
+    static function allocateColor(&$img, $color) {
         $color = Image_Color::color2RGB($color);
 
         return ImageColorAllocate($img, $color[0], $color[1], $color[2]);

--- a/Image/Color.php
+++ b/Image/Color.php
@@ -273,7 +273,7 @@ class Image_Color
      * @static
      * @author  Jason Lotito <jason@lehighweb.com>
      */
-    function getTextColor($color, $light = '#FFFFFF', $dark = '#000000')
+    static function getTextColor($color, $light = '#FFFFFF', $dark = '#000000')
     {
         $color = Image_Color::_splitColor($color);
         if ($color[1] > hexdec('66')) {
@@ -312,7 +312,7 @@ class Image_Color
      * @static
      * @author  Jason Lotito <jason@lehighweb.com>
      */
-    function _splitColor($color)
+    static function _splitColor($color)
     {
         $color = str_replace('#', '', $color);
         $c[] = hexdec(substr($color, 0, 2));
@@ -327,7 +327,7 @@ class Image_Color
      * @deprecated Function deprecated after 1.0.1
      * @see     rgb2hex().
      */
-    function _returnColor ( $color )
+    static function _returnColor ( $color )
     {
         return Image_Color::rgb2hex($color);
     }
@@ -342,7 +342,7 @@ class Image_Color
      * @author  Jason Lotito <jason@lehighweb.com>
      * @see     hex2rgb()
      */
-    function rgb2hex($color)
+    static function rgb2hex($color)
     {
         return sprintf('%02X%02X%02X',$color[0],$color[1],$color[2]);
     }
@@ -359,7 +359,7 @@ class Image_Color
      * @author  Jason Lotito <jason@lehighweb.com>
      * @see     rgb2hex()
      */
-    function hex2rgb($hex)
+    static function hex2rgb($hex)
     {
         $return = Image_Color::_splitColor($hex);
         $return['hex'] = $hex;
@@ -379,7 +379,7 @@ class Image_Color
      * @uses    hsv2hex() to convert the HSV value to Hex.
      * @uses    hex2rgb() to convert the Hex value to RGB.
      */
-    function hsv2rgb($h, $s, $v)
+    static function hsv2rgb($h, $s, $v)
     {
         return Image_Color::hex2rgb(Image_Color::hsv2hex($h, $s, $v));
     }
@@ -399,7 +399,7 @@ class Image_Color
      * @author  Jurgen Schwietering <jurgen@schwietering.com>
      * @uses    rgb2hex() to convert the return value to a hex string.
      */
-    function hsv2hex($h, $s, $v)
+    static function hsv2hex($h, $s, $v)
     {
         $s /= 256.0;
         $v /= 256.0;
@@ -490,7 +490,7 @@ class Image_Color
      * @uses    hex2rgb() to convert colors begining with the # character.
      * @uses    namedColor2RGB() to convert everything not starting with a #.
      */
-    function color2RGB($color)
+    static function color2RGB($color)
     {
         $c = array();
 
@@ -514,7 +514,7 @@ class Image_Color
      * @static
      * @author  Sebastian Bergmann <sb@sebastian-bergmann.de>
      */
-    function namedColor2RGB($color)
+    static function namedColor2RGB($color)
     {
         static $colornames;
 
@@ -680,7 +680,7 @@ class Image_Color
      * @access  public
      * @static
      */
-    function percentageColor2RGB($color)
+    static function percentageColor2RGB($color)
     {
         // remove spaces
         $color = str_replace(' ', '', $color);

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
     },
     "type": "library",
     "require" : {
-        "php": ">=5.6, < 8.0"
+        "php": ">=5.6"
     },
     "require-dev": {
         "yoast/phpunit-polyfills": "^2.0"


### PR DESCRIPTION
This PR ports the code to PHP 8: it now runs from PHP 5.6 to PHP 8.4.

The main changes to the code are:
  - don't use curly braces for accessing array elements (0fd9ba23b11d39943d6785d83632ac131bd33103)
  - some static methods were not declared as static (4e05affd3308d8ebb66f235461bf113e9f3c2205 and fb8a227fa72ce02d37f2e0673fc2c09eeddba1cd)

**This PR is based on the branch used for PR #3 (so this one must be merged first and I must rebase).**